### PR TITLE
Revert commit `11ab6f1` so that parameters are working again (fixes #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.3] - 2026-##-##
 
+### Fixed
+
+- Reverted commit `11ab6f1` so that parameters are working again (fixes #32).
+
 ### Internal
 
 - Added `requirements.txt` file again for easier development (`pip install -r requirements.txt`).

--- a/example.py
+++ b/example.py
@@ -150,6 +150,7 @@ relatics_webservice = RelaticsWebservices(SAMPLE_COMPANY, SAMPLE_WORKSPACE_ID)
 iii = relatics_webservice.get_result(
     operation_name="searchActiesEntrycode",
     parameters={"search": "Excel"},
+    # parameters={},
     authentication="A7C5AE4058E9EA3C9191B9EB68A54C45",
 )
 print(f"Bool evaluation: {bool(iii)}")

--- a/pyrelatics2/client.py
+++ b/pyrelatics2/client.py
@@ -281,6 +281,23 @@ class RelaticsWebservices:
 
         return auth
 
+    def _generate_client(self, authentication: None | str | ClientCredential = None) -> Client:
+        """Generate a suds client and set the user-agent and OAuth2 headers"""
+
+        # Create the client
+        client = Client(self.wsdl_url)
+
+        # Define header
+        headers = {"User-Agent": self.user_agent}
+
+        # Add auth header for OAuth2 requests
+        if isinstance(authentication, ClientCredential):
+            headers["Authorization"] = f"Bearer {authentication.get_token(self.hostname)}"
+
+        client.set_options(headers=headers)
+
+        return client
+
     @overload
     def get_result(
         self,
@@ -337,18 +354,11 @@ class RelaticsWebservices:
         # Basic check of mandatory arguments
         self._check_operation_name(operation_name=operation_name)
 
-        headers = {"User-Agent": self.user_agent}
-        client = Client(self.wsdl_url)
+        client = self._generate_client(authentication)
 
         # Add parameter plugin to handle parameters, when those are set
         if parameters is not None:
             client.set_options(plugins=[AddParametersPlugin(parameters)])
-
-        # Add auth header for OAuth2 requests
-        if isinstance(authentication, ClientCredential):
-            headers["Authorization"] = f"Bearer {authentication.get_token(self.hostname)}"
-
-        client.set_options(headers=headers)
 
         # Any parameters will be handled by the AddParametersPlugin, so don't pass them here
         # GetResult(xs:string Operation, Identification Identification, Parameters Parameters,
@@ -512,10 +522,7 @@ class RelaticsWebservices:
             if len({os.path.split(path)[1] for path in documents}) != len(documents):
                 raise ValueError("Duplicate filenames in document list.")
 
-        headers = {"User-Agent": self.user_agent}
         file_extension = None
-
-        client = Client(self.wsdl_url)
 
         # Prepare the data part
         if isinstance(data, list):
@@ -567,11 +574,7 @@ class RelaticsWebservices:
                 with open(data, "rb") as data_file:
                     data_str = b64encode(data_file.read()).decode("utf-8")
 
-        # Add auth header for OAuth2 requests
-        if isinstance(authentication, ClientCredential):
-            headers["Authorization"] = f"Bearer {authentication.get_token(self.hostname)}"
-
-        client.set_options(headers=headers)
+        client = self._generate_client(authentication)
 
         # Import(xs:string Operation, Identification Identification, Authentication Authentication, xs:string Filename,
         #        xs:string Data)

--- a/pyrelatics2/client.py
+++ b/pyrelatics2/client.py
@@ -169,7 +169,7 @@ class ClientCredential:
 class AddParametersPlugin(MessagePlugin):  # pylint: disable=R0903
     """
     Plugin for Suds Client to add parameters to the request before sending to Relatics. Because parameters use
-    attributes, they can not be defined though the default mechanisms within Suds.
+    attributes, they can not be defined through the default mechanisms within Suds.
 
     Args:
         parameters : Dictionary with the parameters

--- a/pyrelatics2/client.py
+++ b/pyrelatics2/client.py
@@ -19,6 +19,8 @@ from uuid import UUID
 from zipfile import ZipFile
 
 from suds.client import Client
+from suds.plugin import MessageContext
+from suds.plugin import MessagePlugin
 from suds.sax.document import Document
 from suds.sax.element import Element
 from suds.sudsobject import Object as SudsObject
@@ -164,6 +166,51 @@ class ClientCredential:
         )
 
 
+class AddParametersPlugin(MessagePlugin):  # pylint: disable=R0903
+    """
+    Plugin for Suds Client to add parameters to the request before sending to Relatics. Because parameters use
+    attributes, they can not be defined though the default mechanisms within Suds.
+
+    Args:
+        parameters : Dictionary with the parameters
+    """
+
+    def __init__(self, parameters: ParametersOrNone):
+        self.parameters = parameters
+
+    def marshalled(self, context: MessageContext):
+        if self.parameters is not None:
+            # Try to get "Parameters" element, or built when missing
+            try:
+                params = context.envelope.getChild("Body")[0].getChild("Parameters")[0]
+            except TypeError:
+                log.info("Adding parameters to SOAP request")
+                root = context.envelope.getChild("Body")[0]
+                root_prefix = root.findPrefix("http://www.relatics.com/")
+
+                p_1 = Element("Parameters", parent=root)
+                p_1.setPrefix(root_prefix)
+                root.append(p_1)
+
+                p_2 = Element("Parameters", parent=p_1)
+                p_2.setPrefix(root_prefix)
+                p_1.append(p_2)
+
+                params = context.envelope.getChild("Body")[0].getChild("Parameters")[0]
+
+            prefix = params.findPrefix("http://www.relatics.com/")
+
+            # Add the parameters
+            for param_name, param_value in self.parameters.items():
+                elem = Element("Parameter", parent=params)
+                elem.setPrefix(prefix)
+                elem.set(name="Name", value=param_name)
+                elem.set(name="Value", value=param_value)
+                params.append(elem)
+
+        log.debug("Final SOAP envelope: \n%s", context.envelope.str())
+
+
 class RelaticsWebservices:
     """
     Class to communicate with Relatics webservices
@@ -293,28 +340,25 @@ class RelaticsWebservices:
         headers = {"User-Agent": self.user_agent}
         client = Client(self.wsdl_url)
 
+        # Add parameter plugin to handle parameters, when those are set
+        if parameters is not None:
+            client.set_options(plugins=[AddParametersPlugin(parameters)])
+
         # Add auth header for OAuth2 requests
         if isinstance(authentication, ClientCredential):
             headers["Authorization"] = f"Bearer {authentication.get_token(self.hostname)}"
 
         client.set_options(headers=headers)
 
-        # Convert the given params to a structure compatible with the soap client
-        params = (
-            None
-            if parameters is None
-            else {"Parameters": [{"Parameter": {f"_{k}": v for k, v in parameters.items()}}]}
-        )
-
+        # Any parameters will be handled by the AddParametersPlugin, so don't pass them here
         # GetResult(xs:string Operation, Identification Identification, Parameters Parameters,
         #           Authentication Authentication)
         suds_response = client.service.GetResult(
             Operation=operation_name,
             Identification=self.identification,
-            Parameters=params,
+            Parameters=None,
             Authentication=self._generate_auth_parameter(authentication),
         )
-        log.debug("Send SOAP envelop: \n%s", str(client.messages["tx"]))
 
         if auto_parse_response:
             # Parse the raw response into something useful

--- a/pyrelatics2/client.py
+++ b/pyrelatics2/client.py
@@ -183,7 +183,7 @@ class AddParametersPlugin(MessagePlugin):  # pylint: disable=R0903
             # Try to get "Parameters" element, or built when missing
             try:
                 params = context.envelope.getChild("Body")[0].getChild("Parameters")[0]
-            except TypeError:
+            except (TypeError, IndexError, AttributeError):
                 log.info("Adding parameters to SOAP request")
                 root = context.envelope.getChild("Body")[0]
                 root_prefix = root.findPrefix("http://www.relatics.com/")

--- a/pyrelatics2/client.py
+++ b/pyrelatics2/client.py
@@ -179,7 +179,7 @@ class AddParametersPlugin(MessagePlugin):  # pylint: disable=R0903
         self.parameters = parameters
 
     def marshalled(self, context: MessageContext):
-        if self.parameters is not None:
+        if self.parameters:  # So not None nor an empty dict
             # Try to get "Parameters" element, or built when missing
             try:
                 params = context.envelope.getChild("Body")[0].getChild("Parameters")[0]
@@ -356,9 +356,8 @@ class RelaticsWebservices:
 
         client = self._generate_client(authentication)
 
-        # Add parameter plugin to handle parameters, when those are set
-        if parameters is not None:
-            client.set_options(plugins=[AddParametersPlugin(parameters)])
+        # Add parameter plugin to handle any possible parameters
+        client.set_options(plugins=[AddParametersPlugin(parameters)])
 
         # Any parameters will be handled by the AddParametersPlugin, so don't pass them here
         # GetResult(xs:string Operation, Identification Identification, Parameters Parameters,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,11 @@ import os
 import unittest
 from uuid import UUID
 
+from suds.plugin import MessageContext
+from suds.sax.element import Element
+
 from pyrelatics2.client import USER_AGENT
+from pyrelatics2.client import AddParametersPlugin
 from pyrelatics2.client import RelaticsWebservices
 
 # from parameterized import parameterized
@@ -112,6 +116,70 @@ class TestRelaticsWebservices(unittest.TestCase):
                 documents=[filename, os.path.join("pyramid-from-bagpipe", filename)],
             )
         self.assertEqual(str(context.exception), "Duplicate filenames in document list.")
+
+
+class TestAddParametersPlugin(unittest.TestCase):
+    NS_RELATICS = "http://www.relatics.com/"
+    NS_SOAP = "http://schemas.xmlsoap.org/soap/envelope/"
+
+    def _make_context(self) -> MessageContext:
+        """Build a minimal fake SOAP envelope wrapped in a MessageContext."""
+        envelope = Element("Envelope")
+        envelope.addPrefix("soapenv", self.NS_SOAP)
+        envelope.addPrefix("rel", self.NS_RELATICS)
+        envelope.setPrefix("soapenv")
+
+        body = Element("Body", parent=envelope)
+        body.setPrefix("soapenv")
+        envelope.append(body)
+
+        get_result = Element("GetResult", parent=body)
+        get_result.addPrefix("rel", self.NS_RELATICS)
+        get_result.setPrefix("rel")
+        body.append(get_result)
+
+        ctx = MessageContext()
+        ctx.envelope = envelope
+        return ctx
+
+    def test_parameters_are_injected(self):
+        ctx = self._make_context()
+        AddParametersPlugin({"a": "b", "c": "d"}).marshalled(ctx)
+
+        # Navigate: Envelope -> Body -> GetResult
+        get_result = ctx.envelope.getChild("Body")[0]
+
+        # Outer <Parameters> must be the first (and only) child of <GetResult>
+        outer_params = get_result[0]
+        self.assertEqual(outer_params.name, "Parameters", "Outer Parameters element missing")
+
+        # Inner <Parameters> must be a child of the outer one
+        inner_params = outer_params[0]
+        self.assertEqual(inner_params.name, "Parameters", "Inner Parameters element missing")
+
+        # Both Parameter children must be present with the correct attributes
+        param_elems = inner_params.getChildren()
+        self.assertEqual(len(param_elems), 2)
+        self.assertEqual(param_elems[0].name, "Parameter")
+        self.assertEqual(param_elems[0].get("Name"), "a")
+        self.assertEqual(param_elems[0].get("Value"), "b")
+        self.assertEqual(param_elems[1].name, "Parameter")
+        self.assertEqual(param_elems[1].get("Name"), "c")
+        self.assertEqual(param_elems[1].get("Value"), "d")
+
+    def test_parameters_none_omits_parameters_block(self):
+        ctx = self._make_context()
+        AddParametersPlugin(None).marshalled(ctx)
+
+        get_result = ctx.envelope.getChild("Body")[0]
+        self.assertEqual(get_result.getChildren(), [], "Parameters element should not be present when parameters=None")
+
+    def test_parameters_empty_dict_omits_parameters_block(self):
+        ctx = self._make_context()
+        AddParametersPlugin({}).marshalled(ctx)
+
+        get_result = ctx.envelope.getChild("Body")[0]
+        self.assertEqual(get_result.getChildren(), [], "Parameters element should not be present when parameters={}")
 
 
 if __name__ == "__main__":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -147,7 +147,8 @@ class TestAddParametersPlugin(unittest.TestCase):
         AddParametersPlugin({"a": "b", "c": "d"}).marshalled(ctx)
 
         # Navigate: Envelope -> Body -> GetResult
-        get_result = ctx.envelope.getChild("Body")[0]
+        body = ctx.envelope.getChild("Body")
+        get_result = body[0]
 
         # Outer <Parameters> must be the first (and only) child of <GetResult>
         outer_params = get_result[0]
@@ -171,14 +172,16 @@ class TestAddParametersPlugin(unittest.TestCase):
         ctx = self._make_context()
         AddParametersPlugin(None).marshalled(ctx)
 
-        get_result = ctx.envelope.getChild("Body")[0]
+        body = ctx.envelope.getChild("Body")
+        get_result = body[0]
         self.assertEqual(get_result.getChildren(), [], "Parameters element should not be present when parameters=None")
 
     def test_parameters_empty_dict_omits_parameters_block(self):
         ctx = self._make_context()
         AddParametersPlugin({}).marshalled(ctx)
 
-        get_result = ctx.envelope.getChild("Body")[0]
+        body = ctx.envelope.getChild("Body")
+        get_result = body[0]
         self.assertEqual(get_result.getChildren(), [], "Parameters element should not be present when parameters={}")
 
 


### PR DESCRIPTION
Restores correct handling of `parameters` in SOAP `GetResult` calls by reverting the prior approach and reintroducing parameter injection via a Suds `MessagePlugin`.

## Changes Made

- **`AddParametersPlugin`**: Added a Suds `MessagePlugin` to inject `Parameter` attributes into the marshalled SOAP envelope, supporting the required nested `<Parameters><Parameters><Parameter .../></Parameters></Parameters>` structure.
- **Client refactor**: Extracted Suds client creation into `_generate_client()` and reused it in `get_result()` and `run_import()`.
- **Empty parameters guard**: An empty dict `{}` is treated the same as `None` — no `<Parameters>` block is emitted.
- **Robust error handling**: `marshalled()` catches `TypeError`, `IndexError`, and `AttributeError` when locating the `Parameters` element before falling back to creating it.
- **Tests**: Added `TestAddParametersPlugin` in `tests/test_client.py` covering:
  - Parameter injection produces the expected nested SOAP structure.
  - `parameters=None` omits the Parameters block.
  - `parameters={}` omits the Parameters block (treated the same as `None`).
- **`CHANGELOG.md`**: Updated to note the revert/fix for parameter handling.

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
